### PR TITLE
Check for the len in X before using to print training related log

### DIFF
--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -307,7 +307,7 @@ class CRF(BaseEstimator):
         trainer = self._get_trainer()
         train_data = zip(X, y)
 
-        if self.verbose:
+        if self.verbose and "len" in dir(X)::
             train_data = tqdm(train_data, "loading training data to CRFsuite", len(X), leave=True)
 
         for xseq, yseq in train_data:

--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -307,7 +307,7 @@ class CRF(BaseEstimator):
         trainer = self._get_trainer()
         train_data = zip(X, y)
 
-        if self.verbose and "len" in dir(X)::
+        if self.verbose and "len" in dir(X):
             train_data = tqdm(train_data, "loading training data to CRFsuite", len(X), leave=True)
 
         for xseq, yseq in train_data:


### PR DESCRIPTION
In case we use a generator for X, we have to turn the verbose mode off, making the training stats unavailable. References  #4 