### PR TITLE
Correct a tiny misprint in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ sklearn-crfsuite
    :target: https://sklearn-crfsuite.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation
 
-sklearn-crfsuite is thin a CRFsuite_ (python-crfsuite_) wrapper which provides
+sklearn-crfsuite is a thin CRFsuite_ (python-crfsuite_) wrapper which provides
 scikit-learn_-compatible :class:`sklearn_crfsuite.CRF` estimator:
 you can use e.g. scikit-learn model selection utilities
 (cross-validation, hyperparameter optimization) with it, or save/load CRF


### PR DESCRIPTION
"Thin a wrapper" may have been a misprint.
I suggest that it be corrected, as these are the very first words one sees when visiting the page.