### PR TITLE
Use keyword arguments for calls to sklearn.metrics functions

### DIFF
--- a/sklearn_crfsuite/metrics.py
+++ b/sklearn_crfsuite/metrics.py
@@ -56,7 +56,7 @@ def flat_fbeta_score(y_true, y_pred, beta, **kwargs):
     Return F-beta score for sequence items.
     """
     from sklearn import metrics
-    return metrics.fbeta_score(y_true, y_pred, beta, **kwargs)
+    return metrics.fbeta_score(y_true, y_pred, beta=beta, **kwargs)
 
 
 @_flattens_y
@@ -65,7 +65,7 @@ def flat_classification_report(y_true, y_pred, labels=None, **kwargs):
     Return classification report for sequence items.
     """
     from sklearn import metrics
-    return metrics.classification_report(y_true, y_pred, labels, **kwargs)
+    return metrics.classification_report(y_true, y_pred, labels=labels, **kwargs)
 
 
 def sequence_accuracy_score(y_true, y_pred):


### PR DESCRIPTION
Use keyword arguments for the following function calls/arguments:

- metrics.fbeta_score - beta
- metrics.classification_report - labels

Passing these as positional arguments will cause an error from sklearn 0.25.

Scikit-learn enhancement proposal [SLEP009](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep009/proposal.html)