### PR TITLE
Drop requirement for training data to have __len__

### DIFF
--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -308,7 +308,7 @@ class CRF(BaseEstimator):
         train_data = zip(X, y)
 
         if self.verbose:
-            train_data = tqdm(train_data, "loading training data to CRFsuite", len(X), leave=True)
+            train_data = tqdm(train_data, "loading training data to CRFsuite", leave=True)
 
         for xseq, yseq in train_data:
             trainer.append(xseq, yseq)
@@ -320,7 +320,7 @@ class CRF(BaseEstimator):
             test_data = zip(X_dev, y_dev)
 
             if self.verbose:
-                test_data = tqdm(test_data, "loading dev data to CRFsuite", len(X_dev), leave=True)
+                test_data = tqdm(test_data, "loading dev data to CRFsuite", leave=True)
 
             for xseq, yseq in test_data:
                 trainer.append(xseq, yseq, 1)


### PR DESCRIPTION
I'd like to be able to pass in the training data as a generator to reduce memory usage, which crashes `sklear-crfsuite`. Easiest fix is to remove `len(X)`, but I also considered checking if `X` has a `__len__` so people who load their data eagerly get a useful progress indicator