### PR TITLE
Fix sklearn FutureWarning for params not available for cloning.

### DIFF
--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -274,6 +274,9 @@ class CRF(BaseEstimator):
         self.trainer_cls = trainer_cls
         self.training_log_ = None
 
+        self.model_filename = model_filename
+        self.keep_tempfiles = keep_tempfiles
+
         self._tagger = None
         self._info_cached = None
 


### PR DESCRIPTION
using CRF within a sklearn Pipeline, raises a FutureWarning with sklearn 0.23.  This will raise an AttributeError from version 0.24. 

Repro for the warning.

```
from sklearn.pipeline import Pipeline
from sklearn_crfsuite import CRF
from sklearn.preprocessing import StandardScaler
Pipeline([('scaler', StandardScaler()), ('crf', CRF())]).get_params()
/Users/tom/anaconda3/envs/cattrainer/lib/python3.7/site-packages/sklearn/base.py:213: FutureWarning: From version 0.24, get_params will raise an AttributeError if a parameter cannot be retrieved as an instance attribute. Previously it would return None.
  FutureWarning)
```

Tested in jupyter with this change via pip install -e sklearn-crfsuite/. and the proposed change. tox passes.