### PR TITLE
Update estimator.py

### DIFF
--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -263,7 +263,9 @@ class CRF(BaseEstimator):
         self.averaging = averaging
         self.variance = variance
         self.gamma = gamma
-
+        # 09/25/2023 HarryCaveMan add model_filename and keep_tempfiles attr to `self` to comply with sklearn clone api
+        self.model_filename = model_filename
+        self.keep_tempfiles = keep_tempfiles
         self.modelfile = FileResource(
             filename=model_filename,
             keep_tempfiles=keep_tempfiles,


### PR DESCRIPTION
Add `model_filename` and `keep_tempfiles attr` to `self` to comply with sklearn clone api which requires all `__init__` args be instance attributes. 

This is imperative for functionalities in sklearn which use parameterized cloning of estimators. The API requires all `__init__ arguments to also be instance attributes or an `AttributeError` will be raised:
https://github.com/scikit-learn/scikit-learn/blob/7f9bad99d6e0a3e8ddf92a7e5561245224dab102/sklearn/base.py#L194C16-L194C16